### PR TITLE
feat: Ajout de notifications toast colorées pour les méthodes de paie…

### DIFF
--- a/client/src/components/ui/toast.jsx
+++ b/client/src/components/ui/toast.jsx
@@ -26,6 +26,10 @@ const toastVariants = cva(
         default: "border bg-background text-foreground",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
+        orange:
+          "orange group border-orange-500 bg-orange-50 text-orange-700 dark:bg-orange-900 dark:text-orange-200 dark:border-orange-700",
+        wave_blue:
+          "wave_blue group border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-200 dark:border-blue-700",
       },
     },
     defaultVariants: {

--- a/client/src/pages/shopping-view/checkout.jsx
+++ b/client/src/pages/shopping-view/checkout.jsx
@@ -134,7 +134,7 @@ function ShoppingCheckout() {
                 toast({
                   title: "Orange Money: Not yet implemented.",
                   description: "This payment method will be available soon.",
-                  variant: "info",
+                  variant: "orange",
                 });
               }}
             >
@@ -153,7 +153,7 @@ function ShoppingCheckout() {
                 toast({
                   title: "Wave: Not yet implemented.",
                   description: "This payment method will be available soon.",
-                  variant: "info",
+                  variant: "wave_blue",
                 });
               }}
             >


### PR DESCRIPTION
…ment

Ce commit introduit des notifications toast avec des couleurs personnalisées pour les méthodes de paiement Orange Money et Wave.

- De nouvelles variantes 'orange' et 'wave_blue' ont été ajoutées aux options de style du composant toast dans client/src/components/ui/toast.jsx.
- La page checkout.jsx utilise désormais ces variantes lors de l'affichage des messages 'Pas encore implémenté' pour ces méthodes de paiement, fournissant un retour visuel cohérent avec les couleurs des boutons.